### PR TITLE
Add unhandled cases for arrow-to-arrow conversion

### DIFF
--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -338,6 +338,10 @@ impl From<arrow_schema::DataType> for DataType {
             DataType::Decimal128(precision, scale) => Self::Decimal(precision as _, scale as _),
             DataType::Decimal256(precision, scale) => Self::Decimal256(precision as _, scale as _),
             DataType::RunEndEncoded(_, _) => panic!("Run-end encoding not supported by arrow2"),
+            DataType::BinaryView => panic!("BinaryView encoding not supported by arrow2"),
+            DataType::Utf8View => panic!("Utf8View encoding not supported by arrow2"),
+            DataType::ListView(_) => panic!("ListView encoding not supported by arrow2"),
+            DataType::LargeListView(_) => panic!("LargeListView encoding not supported by arrow2"),
         }
     }
 }


### PR DESCRIPTION
This is necessary to compile `re_arrow2` with the `arrow` feature.