### PR TITLE
Pin `arrow`-dependencies to version 52 or 53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 
 [[package]]
 name = "arrow-array"
-version = "52.2.0"
+version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
+checksum = "bd03279cea46569acf9295f6224fbc370c5df184b4d2ecfe97ccb131d5615a7f"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -97,15 +97,15 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.2.1",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "52.2.0"
+version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
+checksum = "9e4a9b9b1d6d7117f6138e13bc4dd5daa7f94e671b70e8c9c4dc37b4f5ecfc16"
 dependencies = [
  "bytes",
  "half 2.2.1",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.2.0"
+version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
+checksum = "e4e75edf21ffd53744a9b8e3ed11101f610e7ceb1a29860432824f1834a1f623"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.2.0"
+version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
+checksum = "b95513080e728e4cec37f1ff5af4f12c9688d47795d17cda80b6ec2cf74d4678"
 
 [[package]]
 name = "arrow2"
@@ -1137,6 +1137,12 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,10 @@ ahash = "0.8"
 memchr = { version = "2.6", optional = true }
 
 # Support conversion to/from arrow-rs
-arrow-buffer = { version = "53", optional = true }
-arrow-schema = { version = "53", optional = true }
-arrow-data = { version = "53", optional = true }
-arrow-array = { version = "53", optional = true }
+arrow-buffer = { version = ">=52, <=53", optional = true }
+arrow-schema = { version = ">=52, <=53", optional = true }
+arrow-data = { version = ">=52, <=53", optional = true }
+arrow-array = { version = ">=52, <=53", optional = true }
 
 half = { version = "2.2", features = ["bytemuck"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,10 @@ ahash = "0.8"
 memchr = { version = "2.6", optional = true }
 
 # Support conversion to/from arrow-rs
-arrow-buffer = { version = ">=52", optional = true }
-arrow-schema = { version = ">=52", optional = true }
-arrow-data = { version = ">=52", optional = true }
-arrow-array = { version = ">=52", optional = true }
+arrow-buffer = { version = "53", optional = true }
+arrow-schema = { version = "53", optional = true }
+arrow-data = { version = "53", optional = true }
+arrow-array = { version = "53", optional = true }
 
 half = { version = "2.2", features = ["bytemuck"] }
 


### PR DESCRIPTION
Hi,

our CI lit up with errors like this:

```
error[E0277]: the trait bound `Arc<(dyn arrow::array::Array + 'static)>: From<Box<dyn re_arrow2::array::Array>>` is not satisfied
   --> /builds/straw/rust-cam/.cargo-proj/registry/src/index.crates.io-6f17d22bba15001f/re_types_core-0.21.0/src/archetype.rs:166:25
    |
166 |             (component, arrow::array::ArrayRef::from(arrow2_array))
    |                         ^^^^^^^^^^^^^^^^^^^^^^ the trait `From<Box<dyn re_arrow2::array::Array>>` is not implemented for `Arc<(dyn arrow::array::Array + 'static)>`
    |
    = help: the following other types implement trait `From<T>`:
              `Arc<B>` implements `From<Cow<'_, B>>`
              `Arc<CStr>` implements `From<&CStr>`
              `Arc<CStr>` implements `From<&mut CStr>`
              `Arc<CStr>` implements `From<CString>`
              `Arc<OsStr>` implements `From<&OsStr>`
              `Arc<OsStr>` implements `From<&mut OsStr>`
              `Arc<OsStr>` implements `From<OsString>`
              `Arc<Path>` implements `From<&Path>`
            and 14 others
error[E0277]: the trait bound `arrow::buffer::Buffer: From<re_arrow2::buffer::Buffer<T>>` is not satisfied
```

I believe this is because rerun 0.21 depends on arrow crates 53 but re_arrow2 0.18 depends on arrow crates >=52. As arrow just released version 54, this is now picked up by re_arrow2, but now clashes with the arrow crates 53.

This PR sets the arrow crates version to 53.